### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "webpack-dev-server": "^3.1.7"
   },
   "dependencies": {
-    "npm": "^6.4.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0"
   }


### PR DESCRIPTION

Hello johnnyborjomi!

It seems like you have npm as one of your (dev-) dependency in got-dudes.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
